### PR TITLE
Fix possible targetkv name mangling

### DIFF
--- a/fs2consulkv.py
+++ b/fs2consulkv.py
@@ -121,7 +121,7 @@ def main():
             for name in files:
                 filepath = os.path.join(root, name)
             
-                targetkv = filepath.replace(args.fs_kv_path,"")
+                targetkv = filepath.replace(args.fs_kv_path, "", 1)
 
                 with open (filepath, "r") as kvfile:
                     value = kvfile.read()


### PR DESCRIPTION
This fixes a bug which occurs when fs_kv_path is a substring of filepath.

I learnt this the hard way:
fs_kv_path=conf
filepath=conf/myapp/application.conf

in consul I wondered why I'm having a key of `conf/myapp/application.`