### PR TITLE
Add CHUNK_SIZE and SLEEP_DELAY options to not overwhelm consul for large KV data

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ optional arguments:
                         Retain trailing newline chars (\n) in values files and
                         do not strip them. Default behavior is to strip them
                         (default: False)
+  -s SLEEP_DELAY, --sleep-delay SLEEP_DELAY
+                        Delay [in seconds] in kv upload loop, to avoid
+                        overwhelming the consul server. Default behavior is
+                        0.000 seconds (default: 0)
+  -u CHUNK_SIZE, --chunk-size CHUNK_SIZE
+                        Number of KV pairs uploaded at once. Default is 64,
+                        the maximum allowed. (default: 64)
   -l LOG_LEVEL, --log-level LOG_LEVEL
                         log level, DEBUG, INFO, etc (default: DEBUG)
   -b LOG_FILE, --log-file LOG_FILE

--- a/fs2consulkv.py
+++ b/fs2consulkv.py
@@ -54,6 +54,9 @@ def main():
     parser.add_argument('-n', '--retain-trailing-newlines', action='store_true', default=False, \
         help="Retain trailing newline chars (\\n) in values files and do not strip them. Default behavior is to strip them")
 
+    parser.add_argument('-s', '--sleep-delay', dest='sleep_delay', default=0, \
+        help="Delay [in seconds] in kv upload loop, to avoid overwhelming the consul server. Default behavior is 0.000 seconds")
+
     parser.add_argument('-l', '--log-level', dest='log_level', default="DEBUG", \
         help="log level, DEBUG, INFO, etc")
     parser.add_argument('-b', '--log-file', dest='log_file', default=None, \
@@ -163,6 +166,8 @@ def main():
             logging.info("PUTing chunk with {} keys @ {}".format(len(kvchunk),url))
 
             response = requests.request("PUT", url, data=json.dumps(kvchunk), headers=headers)
+
+            time.sleep(sleep_delay)
             
             if response.status_code == 200:
                 logging.debug("KVs 'set' OK: {}".format(response.content))


### PR DESCRIPTION
My installation has 300+ KV pairs with about 2MB of data. Consul was responding with HTTP 500 errors (and others) when I tried to sync. Cutting the chunks down from 64 pairs to 1 or 2 fixed this problem, as did adding a .01 second sleep.